### PR TITLE
Normalize search session search terms handling

### DIFF
--- a/job_details_models.py
+++ b/job_details_models.py
@@ -57,10 +57,15 @@ class SearchSession:
     radius: int
     results: List[Dict[str, str]]
     timestamp: datetime
-    
+
     def is_expired(self, timeout_seconds: int = 3600) -> bool:
         """Check if session has expired"""
         return (datetime.now() - self.timestamp).total_seconds() > timeout_seconds
+
+    def __post_init__(self):
+        # Ensure search_terms is always a list to simplify downstream usage
+        if self.search_terms is None:
+            self.search_terms = []
 
 class JobDetailsError(Exception):
     """Base exception for job details retrieval"""

--- a/session_manager.py
+++ b/session_manager.py
@@ -38,7 +38,7 @@ class SessionManager:
         
         session = SearchSession(
             session_id=session_id,
-            search_terms=search_terms,
+            search_terms=search_terms if search_terms is not None else [],
             zip_code=zip_code,
             radius=radius,
             results=results,
@@ -147,7 +147,8 @@ class SessionManager:
             return None
         
         summary = f"Search Session: {session_id[:8]}...\n"
-        summary += f"Search Terms: {', '.join(session.search_terms)}\n"
+        search_terms_text = ', '.join(session.search_terms) if session.search_terms else "None"
+        summary += f"Search Terms: {search_terms_text}\n"
         summary += f"Location: {session.zip_code} (±{session.radius}km)\n"
         summary += f"Results: {len(session.results)} jobs found\n"
         summary += f"Search Time: {session.timestamp.strftime('%Y-%m-%d %H:%M:%S')}"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from session_manager import SessionManager
+
+
+def test_get_session_summary_without_search_terms():
+    manager = SessionManager()
+    job_results = [
+        {
+            "title": "Software Engineer",
+            "company": "Example Corp",
+            "location": "Remote",
+        }
+    ]
+
+    session_id = manager.create_session(results=job_results)
+
+    # The session should normalize missing search terms to an empty list
+    session = manager.get_session(session_id)
+    assert session is not None
+    assert session.search_terms == []
+
+    summary = manager.get_session_summary(session_id)
+    assert summary is not None
+    assert "Search Terms: None" in summary


### PR DESCRIPTION
## Summary
- ensure `SearchSession` normalizes missing search terms to an empty list during initialization
- update session creation and summary generation to coerce `None` search terms and format empty values cleanly
- add a regression test covering summary generation when no search terms are provided

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2b09474848332ae489916d8548a42