### PR TITLE
Offload blocking HTTP calls to thread

### DIFF
--- a/stepstone_server.py
+++ b/stepstone_server.py
@@ -302,9 +302,14 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
             )]
         
         try:
-            # Perform the job search
+            # Perform the job search without blocking the event loop
             logger.info(f"Searching jobs with terms: {search_terms}, zip: {zip_code}, radius: {radius}")
-            results = scraper.search_jobs(search_terms, zip_code, radius)
+            results = await asyncio.to_thread(
+                scraper.search_jobs,
+                search_terms,
+                zip_code,
+                radius,
+            )
             
             # Create session for search results
             all_jobs = []
@@ -389,7 +394,7 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
             
             # Parse job details
             parser = JobDetailParser()
-            details = parser.parse_job_details(job['link'])
+            details = await asyncio.to_thread(parser.parse_job_details, job['link'])
             
             if not details:
                 return [types.TextContent(


### PR DESCRIPTION
## Summary
- offload Stepstone job search requests to asyncio.to_thread to avoid blocking the MCP event loop
- move job details scraping into a worker thread for the same reason

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4eaaf958c8332907f668f6bbe5325