### PR TITLE
Handle malformed job entries during session searches

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""
-Session management for storing and retrieving search results
-"""
+"""Session management for storing and retrieving search results."""
 
+import logging
 import uuid
 from typing import Dict, List, Optional
-from datetime import datetime, timedelta
+from datetime import datetime
 from job_details_models import SearchSession
+
+
+logger = logging.getLogger(__name__)
 
 class SessionManager:
     """Manages search sessions for follow-up questions"""
@@ -90,18 +92,45 @@ class SessionManager:
         
         # Try exact title match first
         for job in session.results:
-            if query_lower in job['title'].lower():
+            if not isinstance(job, dict):
+                logger.warning("Skipping non-dictionary job entry: %r", job)
+                continue
+
+            title = job.get("title")
+            if not isinstance(title, str):
+                logger.warning("Job missing valid title; skipping entry: %r", job)
+                continue
+
+            if query_lower in title.lower():
                 return job
-        
+
         # Try company match
         for job in session.results:
-            if query_lower in job['company'].lower():
+            if not isinstance(job, dict):
+                logger.warning("Skipping non-dictionary job entry: %r", job)
+                continue
+
+            company = job.get("company")
+            if not isinstance(company, str):
+                logger.warning("Job missing valid company; skipping entry: %r", job)
+                continue
+
+            if query_lower in company.lower():
                 return job
-        
+
         # Try partial title match
         query_words = query_lower.split()
         for job in session.results:
-            title_words = job['title'].lower().split()
+            if not isinstance(job, dict):
+                logger.warning("Skipping non-dictionary job entry: %r", job)
+                continue
+
+            title = job.get("title")
+            if not isinstance(title, str):
+                logger.warning("Job missing valid title; skipping entry: %r", job)
+                continue
+
+            title_words = title.lower().split()
             if any(word in title_words for word in query_words):
                 return job
         

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -26,3 +26,34 @@ def test_get_session_summary_without_search_terms():
     summary = manager.get_session_summary(session_id)
     assert summary is not None
     assert "Search Terms: None" in summary
+
+
+def test_find_job_in_session_skips_malformed_entries():
+    manager = SessionManager()
+    job_results = [
+        {"title": None, "company": "Alpha Corp"},
+        {"company": "Beta Corp"},
+        "not a dict",
+        {"title": "Senior Data Scientist", "company": "Gamma"},
+    ]
+
+    session_id = manager.create_session(results=job_results)
+
+    match = manager.find_job_in_session(session_id, "data scientist")
+    assert match is not None
+    assert match["title"] == "Senior Data Scientist"
+
+
+def test_find_job_in_session_returns_none_when_all_entries_invalid():
+    manager = SessionManager()
+    job_results = [
+        {"title": None, "company": None},
+        {"title": 123, "company": "Numeric Title"},
+        {},
+        "not a dict",
+    ]
+
+    session_id = manager.create_session(results=job_results)
+
+    match = manager.find_job_in_session(session_id, "engineer")
+    assert match is None


### PR DESCRIPTION
## Summary
- guard session job lookups against missing title or company data
- log and skip malformed job results during search instead of raising
- add tests covering malformed session job entries for matching and no-match cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a89fb9f08332aa32a9e03f7ae85e