### PR TITLE
Normalize job detail parameters and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,14 @@ Search for job listings using multiple search terms with location-based filterin
 Get detailed information about a specific job from previous search results.
 
 **Parameters:**
-- `query` (string, required): Job title or company name to match against previous search results
+- `query` (string, optional): Job title or company name to match against previous search results.
+  - Provide either `query` or `job_index`.
   - Example: `"AML Specialist"` or `"Deutsche Bank AG"`
-- `session_id` (string, required): Session ID from previous search results
+- `job_index` (integer, optional): 1-based index of the job within stored search results.
+  - Provide either `job_index` or `query`.
+  - Example: `1` selects the first job in the saved results.
+- `session_id` (string, optional): Session ID from previous search results.
+  - Defaults to the latest active session when omitted.
   - Example: `"550e8400-e29b-41d4-a716-446655440000"`
 
 ### Example Usage
@@ -180,6 +185,16 @@ Get detailed information about a specific job from previous search results.
   "parameters": {
     "query": "AML Specialist",
     "session_id": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+#### Follow-up Questions - Get Job Details by Index
+```json
+{
+  "tool": "get_job_details",
+  "parameters": {
+    "job_index": 1
   }
 }
 ```

--- a/session_manager.py
+++ b/session_manager.py
@@ -106,6 +106,19 @@ class SessionManager:
                 return job
         
         return None
+
+    def get_job_by_index(self, session_id: str, job_index: int) -> Optional[Dict[str, str]]:
+        """Retrieve a job by its 1-based index within a session."""
+        session = self.get_session(session_id)
+        if not session:
+            return None
+
+        # Convert to zero-based index for list access
+        zero_based_index = job_index - 1
+        if zero_based_index < 0 or zero_based_index >= len(session.results):
+            return None
+
+        return session.results[zero_based_index]
     
     def get_recent_session(self) -> Optional[SearchSession]:
         """

--- a/tests/test_get_job_details_tool.py
+++ b/tests/test_get_job_details_tool.py
@@ -1,0 +1,145 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from stepstone_server import handle_call_tool, session_manager, JobDetailParser  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    session_manager.sessions.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def parser_spy(monkeypatch):
+    details = SimpleNamespace(
+        title="Detailed Title",
+        company="Example Co",
+        location="Remote",
+        salary=None,
+        employment_type=None,
+        posted_date=None,
+        description="Comprehensive role description",
+        requirements=["Requirement"],
+        benefits=["Benefit"],
+        contact_info={"email": "jobs@example.com"},
+        job_url="http://example.com/details",
+    )
+    called_urls: list[str] = []
+
+    def fake_parse(self, url):
+        called_urls.append(url)
+        return details
+
+    monkeypatch.setattr(JobDetailParser, "parse_job_details", fake_parse)
+    return called_urls, details
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_by_index_uses_latest_session(parser_spy):
+    called_urls, _ = parser_spy
+    job = {
+        "title": "Backend Engineer",
+        "company": "ACME",
+        "description": "Work on APIs",
+        "link": "http://example.com/job",
+    }
+    session_manager.create_session(results=[job], search_terms=["backend"], zip_code="10115", radius=10)
+
+    result = await handle_call_tool(
+        "get_job_details",
+        {
+            "job_index": 1,
+        },
+    )
+
+    assert result
+    assert "Detailed Title" in result[0].text
+    assert called_urls == ["http://example.com/job"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_requires_identifier(parser_spy):
+    response = await handle_call_tool("get_job_details", {})
+    assert response[0].text.startswith("Error: provide either a query string or a job_index")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_validates_job_index(parser_spy):
+    response = await handle_call_tool(
+        "get_job_details",
+        {
+            "job_index": 0,
+        },
+    )
+    assert response[0].text == "Error: job_index must be an integer greater than or equal to 1"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_handles_missing_session(parser_spy):
+    response = await handle_call_tool(
+        "get_job_details",
+        {
+            "query": "Engineer",
+            "session_id": "missing-session",
+        },
+    )
+
+    assert "Session not found or expired" in response[0].text
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_reports_missing_index(parser_spy):
+    response = await handle_call_tool(
+        "get_job_details",
+        {
+            "session_id": session_manager.create_session(
+                results=[{
+                    "title": "Data Scientist",
+                    "company": "DataCorp",
+                    "description": "Analyze data",
+                    "link": "http://example.com/datasci",
+                }],
+                search_terms=["data"],
+                zip_code="10115",
+                radius=10,
+            ),
+            "job_index": 2,
+        },
+    )
+
+    assert "No job found at the requested index" in response[0].text
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_job_details_uses_query_when_provided(parser_spy):
+    session_manager.create_session(
+        results=[{
+            "title": "Cloud Architect",
+            "company": "Nimbus",
+            "description": "Design infrastructure",
+            "link": "http://example.com/cloud",
+        }],
+        search_terms=["cloud"],
+        zip_code="10115",
+        radius=10,
+    )
+
+    response = await handle_call_tool(
+        "get_job_details",
+        {
+            "query": "Cloud Architect",
+        },
+    )
+
+    assert response
+    assert "Detailed Title" in response[0].text


### PR DESCRIPTION
## Summary
- align the `get_job_details` tool schema with canonical `query`, `session_id`, and `job_index` parameters
- document the refreshed parameter requirements and examples in the README
- add job index lookup support and unit coverage for the updated parameter handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a95657408332a5fe03a2e1f96791