### PR TITLE
Remove unused lxml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ curl -X POST http://localhost:8080/health
 python --version  # Should be 3.8+
 
 # Verify dependencies
-pip list | grep -E "(requests|beautifulsoup4|mcp|lxml)"
+pip list | grep -E "(requests|beautifulsoup4|mcp)"
 
 # Check file permissions
 ls -la stepstone_server.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 mcp>=1.0.0
-lxml>=4.9.0


### PR DESCRIPTION
## Summary
- remove the unused `lxml` requirement since the scraper relies on BeautifulSoup's built-in HTML parser
- update the troubleshooting guide to reflect the slimmer dependency list

## Testing
- `pytest` *(fails: known issues in handle_call_tool and search_jobs tests unrelated to dependency change)*

------
https://chatgpt.com/codex/tasks/task_e_68d79d721148833286d8c8078e1da90a