### PR TITLE
Add guidance for empty job searches

### DIFF
--- a/stepstone_server.py
+++ b/stepstone_server.py
@@ -348,7 +348,9 @@ async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent
                 formatted_output.append(f"\n--- Results for '{term}' ---")
 
                 if not jobs:
-                    formatted_output.append("No jobs found for this search term.")
+                    formatted_output.append(
+                        "No jobs found for this search term. Try refining your search terms or expanding the radius."
+                    )
                 else:
                     for i, job in enumerate(jobs, 1):
                         formatted_output.append(f"\n{i}. {job['title']}")

--- a/tests/test_handle_call_tool.py
+++ b/tests/test_handle_call_tool.py
@@ -53,7 +53,7 @@ def test_handle_call_tool_search_jobs_empty_results(monkeypatch):
     text = response[0].text
     assert "Total Jobs Found: 0" in text
     assert "No jobs found for this search term." in text
-    assert "Try adjusting your search terms" in text
+    assert "Try refining your search terms or expanding the radius." in text
 
 
 def test_handle_call_tool_search_jobs_error(monkeypatch):
@@ -98,7 +98,7 @@ def test_handle_call_tool_get_job_details_success(monkeypatch):
 
     response = asyncio.run(handle_call_tool(
         "get_job_details",
-        {"job_query": "Fraud Analyst", "session_id": session_id},
+        {"query": "Fraud Analyst", "session_id": session_id},
     ))
 
     text = response[0].text
@@ -123,7 +123,7 @@ def test_handle_call_tool_get_job_details_no_match(monkeypatch):
 
     response = asyncio.run(handle_call_tool(
         "get_job_details",
-        {"job_query": "Data Scientist", "session_id": list(session_manager.sessions.keys())[0]},
+        {"query": "Data Scientist", "session_id": list(session_manager.sessions.keys())[0]},
     ))
 
     assert response[0].text == "No job found matching: Data Scientist"
@@ -145,7 +145,7 @@ def test_handle_call_tool_get_job_details_error(monkeypatch):
 
     response = asyncio.run(handle_call_tool(
         "get_job_details",
-        {"job_query": "Fraud Analyst", "session_id": session_id},
+        {"query": "Fraud Analyst", "session_id": session_id},
     ))
 
     assert "Error retrieving job details: parse failure" in response[0].text

--- a/tests/test_stepstone_server.py
+++ b/tests/test_stepstone_server.py
@@ -34,7 +34,7 @@ async def test_search_jobs_no_results(monkeypatch, caplog):
 
     assert "Total Jobs Found: 0" in message
     assert "No jobs found for this search term." in message
-    assert "refining your search terms" in message
+    assert "Try refining your search terms or expanding the radius." in message
 
     assert any("returned no results" in record.getMessage() for record in caplog.records)
 


### PR DESCRIPTION
## Summary
- add guidance text to empty job search results encouraging users to refine terms or expand the radius
- update tests to expect the new message and align get_job_details calls with the server interface

## Testing
- pytest tests/test_handle_call_tool.py tests/test_stepstone_server.py

------
https://chatgpt.com/codex/tasks/task_e_68d79d6cd24c8332b0f4c5914f93ceb3