### PR TITLE
Normalize search term handling in Stepstone MCP server

### DIFF
--- a/tests/test_stepstone_scraper.py
+++ b/tests/test_stepstone_scraper.py
@@ -64,6 +64,21 @@ def test_search_jobs_with_no_terms_returns_empty(monkeypatch, scraper):
     assert call_count == 0
 
 
+def test_search_jobs_normalizes_terms(monkeypatch, scraper):
+    observed_terms = []
+
+    def fake_fetch(self, url):
+        observed_terms.append(unquote(url.split("/jobs/")[1].split("/in-")[0]))
+        return []
+
+    monkeypatch.setattr(StepstoneJobScraper, "fetch_job_listings", fake_fetch)
+
+    results = scraper.search_jobs([" Fraud ", "fraud", "DATA", "data", ""], zip_code="12345", radius=15)
+
+    assert observed_terms == ["Fraud", "DATA"]
+    assert results == {"Fraud": [], "DATA": []}
+
+
 SAMPLE_HTML = """
 <html>
     <body>


### PR DESCRIPTION
## Summary
- add normalization that trims, deduplicates, and filters invalid search terms before querying Stepstone
- return clear validation feedback when no usable search terms are provided
- cover the new behavior with scraper and tool handler unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc1070b1cc833293f9719461dfdf6a