### PR TITLE
Fix start command path for hosted deployment

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -17,9 +17,10 @@ build:
 # raw STDIO entry point.
 startCommand:
   type: http
-  command: .venv/bin/python
+  command: /app/.venv/bin/python
   args:
-    - stepstone_http_server.py
+    - -m
+    - stepstone_http_server
 
 # Session configuration documented at
 # https://smithery.ai/docs/build/session-config. Providing it inline keeps the


### PR DESCRIPTION
## Summary
- update the Smithery start command to invoke the HTTP transport using the virtualenv's python
- call the HTTP server module via ``python -m`` so the app starts correctly regardless of the working directory

## Testing
- python test-server.py

------
https://chatgpt.com/codex/tasks/task_e_68f772af9a248332b00f6e4c4321237b