### PR TITLE
Expose absolute MCP endpoint URL in HTTP metadata

### DIFF
--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -36,7 +36,8 @@ def test_homepage_reports_status():
     assert response.status_code == 200
     payload = response.json()
     assert payload["status"] == "ok"
-    assert payload["endpoints"]["mcp"] == "/mcp"
+    assert payload["endpoints"]["mcp"].endswith("/mcp")
+    assert payload["endpoints"]["mcpPath"] == "/mcp"
     assert response.headers["access-control-allow-origin"] == "https://foo"
     assert response.headers["access-control-allow-credentials"] == "true"
     assert response.headers["vary"] == "origin"


### PR DESCRIPTION
## Summary
- return a fully-qualified MCP endpoint URL on the HTTP homepage response while keeping the legacy relative path
- name the MCP routes so the Starlette app can build absolute endpoint links for metadata consumers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f7745a2c7c8332957bcf62f3a36125