### PR TITLE
Add missing HTTP port setting to Smithery configuration

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -17,6 +17,7 @@ build:
 # raw STDIO entry point.
 startCommand:
   type: http
+  port: 8000
   command: /app/.venv/bin/python
   args:
     - -m


### PR DESCRIPTION
## Summary
- configure the hosted HTTP start command to advertise port 8000 so the service can deploy correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f776b7aae483329d20e699590d42be